### PR TITLE
Add travis-ci for hacktoberfest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,7 @@ env:
     - GO111MODULE=on
 
 script:
+  - go fmt
+  - go vet
+  - go test
   - make build

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: go
+
+go:
+  - "1.11.x"
+
+env:
+  global:
+    - GO111MODULE=on
+
+script:
+  - make build

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ go:
   - "1.11.x"
 
 script:
-  - GO111MODULE=on go fmt
+  - GO111MODULE=on make build
   - GO111MODULE=on go vet
   - GO111MODULE=on go test
-  - GO111MODULE=on make build

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,8 @@ language: go
 go:
   - "1.11.x"
 
-env:
-  global:
-    - GO111MODULE=on
-
 script:
-  - go fmt
-  - go vet
-  - go test
-  - make build
+  - GO111MODULE=on go fmt
+  - GO111MODULE=on go vet
+  - GO111MODULE=on go test
+  - GO111MODULE=on make build


### PR DESCRIPTION
I first added circleci, then travis-ci.  Both are having problems because of the GO 1.11 GOMODULES changes.  Tools still expect the source code to be in $GOPATH.

The present solution in both CI/CD's is to preappend commands with GO111MODULES=on.  This should go away in Go >= 1.12

Also - it is failing on my side  because it looks for billglover/bbot and not dangarthwaite/bbot.  I'm making this pull request because that might be fixed once merged.  