### PR TITLE
Ignore node_modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Serverless directories
 .serverless
+node_modules
 
 # golang output binary directory
 bin


### PR DESCRIPTION
The contents of `node_modules` are created when installing serverless plugins. These are not part of the BuddyBot codebase and so I'm excluding them from the repository for now.